### PR TITLE
Clean and add nb_config_manager dependency

### DIFF
--- a/.binstar.yml
+++ b/.binstar.yml
@@ -9,6 +9,6 @@ engine:
   - python=3.5
 
 script:
-  - conda build conda.recipe -c javascript
+  - conda build conda.recipe -c javascript -c anaconda-nb-extensions
 
 build_targets: conda

--- a/conda.recipe/meta.yaml
+++ b/conda.recipe/meta.yaml
@@ -20,6 +20,7 @@ requirements:
     - funcsigs
     - pyqt
     - futures
+    - nb_config_manager
 
 test:
   imports:

--- a/nbbrowserpdf/install.py
+++ b/nbbrowserpdf/install.py
@@ -45,6 +45,8 @@ def install(enable=False, **kwargs):
             if not exists(path):
                 print("Making directory", path)
                 os.makedirs(path)
+        else:
+            path = jupyter_config_dir()
 
         cm = ConfigManager(config_dir=path)
         print("Enabling nbbrowserpdf server component in", cm.config_dir)
@@ -62,15 +64,7 @@ def install(enable=False, **kwargs):
         print("New config...")
         pprint(cm.get("jupyter_notebook_config"))
 
-        try:
-            subprocess.call(["conda", "info", "--root"])
-            print("conda detected")
-            _jupyter_config_dir = ENV_CONFIG_PATH[0]
-        except OSError:
-            print("conda not detected")
-            _jupyter_config_dir = jupyter_config_dir()
-
-        cm = ConfigManager(config_dir=join(_jupyter_config_dir, "nbconfig"))
+        cm = ConfigManager(config_dir=join(path, "nbconfig"))
         print(
             "Enabling nbpresent nbextension at notebook launch in",
             cm.config_dir


### PR DESCRIPTION
Removing old stuff... and enabling the CM to write in path instead of hardcoding the `jupyter_config_dir`.
Also using `nb_config_manager` as a conda dependency (this should not affect people trying this with pip, but enforce people suing conda to use the custom config manager until this is fixed upstream in the notebook 4.2).